### PR TITLE
Update materialish to 0.17.0-beta.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "helmet": "3.9.0",
     "history": "4.7.2",
     "lodash": "4.17.10",
-    "materialish": "0.17.0-beta.3",
+    "materialish": "0.17.0-beta.5",
     "no-scroll": "2.1.1",
     "pino": "4.10.3",
     "query-string": "5.0.1",


### PR DESCRIPTION
The version of Materialish currently in use suffers from this bug: https://github.com/jamesplease/materialish/issues/279 (unsized icons in Firefox, see screenshot). This bug was fixed in a more recent release.

<img width="702" alt="screen shot 2018-10-12 at 1 00 19 pm" src="https://user-images.githubusercontent.com/428195/46883123-f7691580-ce1e-11e8-8403-21caab6cc3f2.png">
