### PR TITLE
Improve linting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,11 @@
     "plugin:import/errors",
     "plugin:import/warnings"
   ],
+  "settings": {
+    "react": {
+      "version": "16.4"
+    }
+  },
   "rules": {
     "no-unused-vars": "error",
     "no-use-before-define": "error",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "watch": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
-    "lint": "eslint src/**/*.js",
+    "lint": "eslint src",
     "eject": "react-scripts eject",
     "deploy": "bash deploy/to-staging.sh",
     "deploy-staging": "bash deploy/to-staging.sh",


### PR DESCRIPTION
This PR _may_ fix #51.

I suspect the current glob specified in `package.json` is ambiguous. (I may be wrong!) Per [ESLint's documentation](https://eslint.org/docs/user-guide/command-line-interface):

> Please note that when passing a glob as a parameter, it will be expanded by your shell. The results of the expansion can vary depending on your shell, and its configuration.

This change also addresses this warning from appearing post-run:
```
Warning: React version not specified in eslint-plugin-react settings. See https://github.com/yannickcr/eslint-plugin-react#configuration.
```