### PR TITLE
Support too-small screens for modals

### DIFF
--- a/src/calculator/dialog.css
+++ b/src/calculator/dialog.css
@@ -4,10 +4,11 @@
   left: 10px;
   top: 12vh;
   min-height: 10rem;
+  max-height: 76vh;
   z-index: 2000;
   background: #fff;
   border-radius: 10px;
-  overflow: hidden;
+  overflow: hidden auto;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
This fixes #46.

![Screen Shot 2019-10-03 at 20 53 08](https://user-images.githubusercontent.com/428195/66173937-bade8d00-e620-11e9-9290-54a37476977d.png)

(You can't appreciate the vertical scrollbar in this static screenshot, but it's there.)