### PR TITLE
Update format of types in sim-engine

### DIFF
--- a/src/vendor/@moolah/simulation-engine/run-simulation.ts
+++ b/src/vendor/@moolah/simulation-engine/run-simulation.ts
@@ -2,10 +2,10 @@ import _ from 'lodash';
 import { inflationFromCpi } from '../../@moolah/lib';
 import {
   Portfolio,
-  WithdrawalStrategyForm,
+  WithdrawalStrategyInput,
   WithdrawalStrategies,
   YearResult,
-  AdditionalWithdrawals,
+  AdditionalWithdrawalsInput,
   Simulation,
   MarketDataInput
 } from './types';
@@ -17,10 +17,10 @@ interface RunSimulationOptions {
   startYear: number;
   duration: number;
   rebalancePortfolioAnnually: boolean;
-  withdrawalStrategy: WithdrawalStrategyForm;
+  withdrawalStrategy: WithdrawalStrategyInput;
   portfolio: Portfolio;
-  additionalWithdrawals: AdditionalWithdrawals;
-  additionalIncome: AdditionalWithdrawals;
+  additionalWithdrawals: AdditionalWithdrawalsInput;
+  additionalIncome: AdditionalWithdrawalsInput;
   marketData: MarketDataInput
 }
 

--- a/src/vendor/@moolah/simulation-engine/simulate-one-year.ts
+++ b/src/vendor/@moolah/simulation-engine/simulate-one-year.ts
@@ -4,7 +4,7 @@ import {
   YearMarketData,
   YearResult,
   Portfolio,
-  AdditionalWithdrawals,
+  AdditionalWithdrawalsInput,
 } from './types';
 
 interface SimulateOneYearOptions {
@@ -14,8 +14,8 @@ interface SimulateOneYearOptions {
   rebalancePortfolioAnnually: boolean;
   startPortfolio: Portfolio;
 
-  additionalWithdrawalsForYear: AdditionalWithdrawals;
-  additionalIncomeForYear: AdditionalWithdrawals;
+  additionalWithdrawalsForYear: AdditionalWithdrawalsInput;
+  additionalIncomeForYear: AdditionalWithdrawalsInput;
 
   yearMarketData: YearMarketData;
 

--- a/src/vendor/@moolah/simulation-engine/types.ts
+++ b/src/vendor/@moolah/simulation-engine/types.ts
@@ -16,13 +16,13 @@ export interface YearMarketData {
   [MarketDataGrowthKeys.none]: number;
 }
 
-export interface LengthOfRetirement {
+export interface LengthOfRetirementInput {
   numberOfYears: number;
   startYear: number;
   endYear: number;
 }
 
-export interface HistoricalDataRange {
+export interface HistoricalDataRangeInput {
   firstYear: number;
   lastYear: number;
   useAllHistoricalData: boolean;
@@ -36,7 +36,7 @@ export interface AdditionalWithdrawal {
   startYear: number;
 }
 
-export type AdditionalWithdrawals = AdditionalWithdrawal[];
+export type AdditionalWithdrawalsInput = AdditionalWithdrawal[];
 
 export interface PortfolioInvestment {
   percentage: number;
@@ -46,7 +46,7 @@ export interface PortfolioInvestment {
   annualGrowthAmount?: number;
 }
 
-export interface PortfolioForm {
+export interface PortfolioInput {
   bondsValue: number;
   stockInvestmentValue: number;
   stockInvestmentFees: number;
@@ -58,7 +58,7 @@ export interface Portfolio {
   investments: PortfolioInvestment[];
 }
 
-export interface WithdrawalStrategyForm {
+export interface WithdrawalStrategyInput {
   withdrawalStrategyName: {
     key: string;
   };
@@ -162,12 +162,12 @@ export interface MarketDataInput {
 }
 
 export interface RunSimulationsOptions {
-  lengthOfRetirement: LengthOfRetirement;
-  withdrawalStrategy: WithdrawalStrategyForm;
-  portfolio: PortfolioForm;
-  historicalDataRange: HistoricalDataRange;
-  additionalWithdrawals: AdditionalWithdrawals;
-  additionalIncome: AdditionalWithdrawals;
+  lengthOfRetirement: LengthOfRetirementInput;
+  withdrawalStrategy: WithdrawalStrategyInput;
+  portfolio: PortfolioInput;
+  historicalDataRange: HistoricalDataRangeInput;
+  additionalWithdrawals: AdditionalWithdrawalsInput;
+  additionalIncome: AdditionalWithdrawalsInput;
   calculationId: number;
   analytics: any;
   marketData: MarketDataInput;

--- a/src/vendor/@moolah/simulation-engine/utils/get-first-year-start-portfolio.ts
+++ b/src/vendor/@moolah/simulation-engine/utils/get-first-year-start-portfolio.ts
@@ -1,8 +1,8 @@
-import { PortfolioForm, InvestmentType, Portfolio } from '../types';
+import { PortfolioInput, InvestmentType, Portfolio } from '../types';
 import { fromInvestments } from './normalize-portfolio';
 
 interface GetFirstYearStartPortfolioOptions {
-  portfolioForm: PortfolioForm;
+  portfolioForm: PortfolioInput;
 }
 
 export default function getFirstYearStartPortfolio({


### PR DESCRIPTION
Resolves #162 

the sim-engine has no notion of forms, so `input` seemed like a more appropriate suffix.