### PR TITLE
Add run-sim test

### DIFF
--- a/src/form-config/length-of-retirement-form-config.js
+++ b/src/form-config/length-of-retirement-form-config.js
@@ -3,9 +3,6 @@ import {
   numberRequired,
   integerRequired,
   greaterThanZero,
-  withinYearLimit,
-  lessThanEndYear,
-  greaterThanStartYear,
 } from '../utils/forms/validators';
 
 export default {
@@ -18,30 +15,6 @@ export default {
         numberRequired,
         integerRequired,
         greaterThanZero,
-      ],
-    },
-
-    startYear: {
-      type: 'number',
-      default: 1931,
-      validators: [
-        isRequired,
-        numberRequired,
-        integerRequired,
-        withinYearLimit,
-        lessThanEndYear,
-      ],
-    },
-
-    endYear: {
-      type: 'number',
-      default: 1960,
-      validators: [
-        isRequired,
-        numberRequired,
-        integerRequired,
-        withinYearLimit,
-        greaterThanStartYear,
       ],
     },
   },

--- a/src/vendor/@moolah/simulation-engine/tests/simulation-engine/index.test.ts
+++ b/src/vendor/@moolah/simulation-engine/tests/simulation-engine/index.test.ts
@@ -1,0 +1,106 @@
+import runSimulations from '../../index';
+
+describe('runSimulation', () => {
+  it('it returns the expected data', done => {
+    const result = runSimulations({
+      yearlyWithdrawal() {
+        return 40000;
+      },
+      lengthOfRetirement: {
+        numberOfYears: 3,
+      },
+      portfolio: {
+        bondsValue: 0,
+        stockInvestmentFees: 0.04,
+        stockInvestmentValue: 1000000,
+      },
+      historicalDataRange: {
+        firstYear: 1930,
+        lastYear: 1932,
+        useAllHistoricalData: true,
+      },
+      additionalWithdrawals: [],
+      additionalIncome: [],
+      calculationId: 1,
+      analytics: {},
+      marketData: {
+        byYear: {
+          1930: {
+            year: 1930,
+            month: 1,
+            startCpi: 100,
+            endCpi: 100,
+            cape: 100,
+            inflationOverPeriod: 1,
+            dividendYields: 0,
+            bondsGrowth: 0,
+            stockMarketGrowth: 0,
+            none: 0,
+          },
+          1931: {
+            year: 1931,
+            month: 1,
+            startCpi: 100,
+            endCpi: 100,
+            inflationOverPeriod: 1,
+            cape: 100,
+            dividendYields: 0,
+            bondsGrowth: 0,
+            stockMarketGrowth: 0,
+            none: 0,
+          },
+          1932: {
+            year: 1932,
+            month: 1,
+            startCpi: 100,
+            endCpi: 100,
+            inflationOverPeriod: 1,
+            cape: 100,
+            dividendYields: 0,
+            bondsGrowth: 0,
+            stockMarketGrowth: 0,
+            none: 0,
+          },
+          1933: {
+            year: 1933,
+            month: 1,
+            startCpi: 100,
+            endCpi: 100,
+            inflationOverPeriod: 1,
+            cape: 100,
+            dividendYields: 0,
+            bondsGrowth: 0,
+            stockMarketGrowth: 0,
+            none: 0,
+          },
+          1934: {
+            year: 1934,
+            month: 1,
+            startCpi: 100,
+            endCpi: 100,
+            inflationOverPeriod: 1,
+            cape: 100,
+            dividendYields: 0,
+            bondsGrowth: 0,
+            stockMarketGrowth: 0,
+            none: 0,
+          },
+        },
+        lastSupportedYear: 1934,
+        avgMarketDataCape: 100,
+      },
+    });
+
+    expect(result instanceof Promise).toBe(true);
+
+    result.then(res => {
+      expect(res.calculationId).toEqual(1);
+      expect(res.simulations).toHaveLength(2);
+      expect(res.completeSimulations).toHaveLength(2);
+      expect(res.incompleteSimulations).toHaveLength(0);
+      expect(res.analysis).toEqual({});
+
+      done();
+    });
+  });
+});

--- a/src/vendor/@moolah/simulation-engine/types.ts
+++ b/src/vendor/@moolah/simulation-engine/types.ts
@@ -16,8 +16,6 @@ export interface YearMarketData {
 
 export interface LengthOfRetirementInput {
   readonly numberOfYears: number;
-  readonly startYear: number;
-  readonly endYear: number;
 }
 
 export interface HistoricalDataRangeInput {


### PR DESCRIPTION
As part of #158 

--

This also gets rid of the old `startYear`/`endYear` from `lengthOfRetirement`, which are form inputs from an old version of FI Calc